### PR TITLE
0.2.0

### DIFF
--- a/.changeset/great-emus-share.md
+++ b/.changeset/great-emus-share.md
@@ -1,0 +1,5 @@
+---
+"postcss-variable-theming": minor
+---
+
+Use `@var` rule name rather than `@theme`

--- a/.changeset/hungry-islands-relax.md
+++ b/.changeset/hungry-islands-relax.md
@@ -1,0 +1,5 @@
+---
+"postcss-variable-theming": minor
+---
+
+Support rest parameters as fallback name

--- a/.changeset/long-eyes-care.md
+++ b/.changeset/long-eyes-care.md
@@ -1,0 +1,5 @@
+---
+"postcss-variable-theming": minor
+---
+
+Add an `atRuleName` option

--- a/.changeset/poor-games-leave.md
+++ b/.changeset/poor-games-leave.md
@@ -1,0 +1,5 @@
+---
+"postcss-variable-theming": patch
+---
+
+Allow an empty string for `propDelimiter` and `nestedThemeDelimiter` options

--- a/plugins/postcss-variable-theming/README.md
+++ b/plugins/postcss-variable-theming/README.md
@@ -120,6 +120,7 @@ module.exports = {
     prefix: '',
     propDelimiter: '-',
     nestedThemeDelimiter: '--',
+    atRuleName: 'var',
   })],
 };
 ```
@@ -138,3 +139,8 @@ module.exports = {
 
 * Type: `string`
 * Default: `'--'`
+
+### `atRuleName`
+
+* Type: `string`
+* Default: `var`

--- a/plugins/postcss-variable-theming/README.md
+++ b/plugins/postcss-variable-theming/README.md
@@ -34,24 +34,22 @@ module.exports = {
   }
 }
 
-@var-fallback heading {
-  @var h1 {
-    h1 {
-      font-size: 2em;
-      line-height: 1.5;
-    }
+@var h1, heading {
+  h1 {
+    font-size: 2em;
+    line-height: 1.5;
   }
-  @var h2 {
-    h2 {
-      font-size: 1.5em;
-      line-height: 1.5;
-    }
+}
+@var h2, heading {
+  h2 {
+    font-size: 1.5em;
+    line-height: 1.5;
   }
-  @var h3 {
-    h3 {
-      font-size: 1.17em;
-      line-height: 1.5;
-    }
+}
+@var h3, heading {
+  h3 {
+    font-size: 1.17em;
+    line-height: 1.5;
   }
 }
 ```

--- a/plugins/postcss-variable-theming/README.md
+++ b/plugins/postcss-variable-theming/README.md
@@ -4,7 +4,7 @@
 
 [npm-url]: https://www.npmjs.com/package/postcss-variable-theming
 
-> PostCSS plugin to provide theming function based on CSS variables using `@theme` rules.
+> PostCSS plugin to provide theming function based on CSS variables using `@var` rules.
 
 ## Installation
 
@@ -27,27 +27,27 @@ module.exports = {
 ```css
 /* Input CSS */
 
-@theme foo {
+@var foo {
   :root {
     font: 16px / 1.5;
     color: ;
   }
 }
 
-@theme-fallback heading {
-  @theme h1 {
+@var-fallback heading {
+  @var h1 {
     h1 {
       font-size: 2em;
       line-height: 1.5;
     }
   }
-  @theme h2 {
+  @var h2 {
     h2 {
       font-size: 1.5em;
       line-height: 1.5;
     }
   }
-  @theme h3 {
+  @var h3 {
     h3 {
       font-size: 1.17em;
       line-height: 1.5;
@@ -82,17 +82,17 @@ h3 {
 ```css
 /* Input CSS */
 
-@theme {
+@var {
   :root {
     --color-1: orange;
   }
-  @theme foo.bar {
+  @var foo.bar {
     :root {
       --color-2: green;
     }
   }
-  @theme foo {
-    @theme baz {
+  @var foo {
+    @var baz {
       :root {
         --color-3: purple;
       }

--- a/plugins/postcss-variable-theming/package.json
+++ b/plugins/postcss-variable-theming/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postcss-variable-theming",
   "version": "0.1.0",
-  "description": "PostCSS plugin to provide theming function based on CSS variables using @theme rules.",
+  "description": "PostCSS plugin to provide theming function based on CSS variables using @var rules.",
   "author": "spring-raining <harusamex.com@gmail.com>",
   "license": "MIT",
   "type": "module",

--- a/plugins/postcss-variable-theming/package.json
+++ b/plugins/postcss-variable-theming/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w --preserveWatchOutput",
+    "try": "postcss --config ./postcss.config.js",
     "test": "node --test ./test/index.js"
   },
   "devDependencies": {

--- a/plugins/postcss-variable-theming/src/index.ts
+++ b/plugins/postcss-variable-theming/src/index.ts
@@ -6,7 +6,7 @@ export interface PluginOptions {
   nestedThemeDelimiter?: string;
 }
 
-const atRuleNameFilter = /^theme|theme-fallback$/;
+const atRuleNameFilter = /^var|var-fallback$/;
 const visited = Symbol('visited');
 
 function processAtRule(
@@ -18,7 +18,7 @@ function processAtRule(
     const context = [parentNs, atRule.params].filter(Boolean).join('.');
     const fb = [...fallbacks];
     let ns = parentNs;
-    if (atRule.name === 'theme-fallback') {
+    if (atRule.name === 'var-fallback') {
       fb.unshift(context);
     } else {
       ns = context;

--- a/plugins/postcss-variable-theming/src/index.ts
+++ b/plugins/postcss-variable-theming/src/index.ts
@@ -55,9 +55,9 @@ function processAtRule(
 
 const Plugin: PluginCreator<PluginOptions> = (options = {}) => {
   const opts = {
-    prefix: options.prefix || '',
-    propDelimiter: options.propDelimiter || '-',
-    nestedThemeDelimiter: options.nestedThemeDelimiter || '--',
+    prefix: options.prefix ?? '',
+    propDelimiter: options.propDelimiter ?? '-',
+    nestedThemeDelimiter: options.nestedThemeDelimiter ?? '--',
   };
   return {
     postcssPlugin: 'variable-theming',

--- a/plugins/postcss-variable-theming/test/css/1.css
+++ b/plugins/postcss-variable-theming/test/css/1.css
@@ -1,4 +1,4 @@
-@theme {
+@var {
   html {
     font: 16px / 1.5;
     color: ;

--- a/plugins/postcss-variable-theming/test/css/2.css
+++ b/plugins/postcss-variable-theming/test/css/2.css
@@ -1,6 +1,6 @@
-@theme foo {
-  @theme bar {
-    @theme baz {
+@var foo {
+  @var bar {
+    @var baz {
       :root {
         color: red;
       }
@@ -13,14 +13,14 @@
 }
 
 @media screen {
-  @theme a {
+  @var a {
     :root {
       color: green;
     }
   }
 }
 
-@theme b {
+@var b {
   @media screen {
     :root {
       color: purple;

--- a/plugins/postcss-variable-theming/test/css/3.css
+++ b/plugins/postcss-variable-theming/test/css/3.css
@@ -1,12 +1,8 @@
 @var a {
-  @var-fallback x {
-    @var b {
-      @var-fallback y {
-        @var c {
-          html {
-            font-weight: bold;
-          }
-        }
+  @var b, x {
+    @var c, y {
+      html {
+        font-weight: bold;
       }
     }
   }

--- a/plugins/postcss-variable-theming/test/css/3.css
+++ b/plugins/postcss-variable-theming/test/css/3.css
@@ -1,8 +1,8 @@
-@theme a {
-  @theme-fallback x {
-    @theme b {
-      @theme-fallback y {
-        @theme c {
+@var a {
+  @var-fallback x {
+    @var b {
+      @var-fallback y {
+        @var c {
           html {
             font-weight: bold;
           }

--- a/plugins/postcss-variable-theming/test/css/3.expect.css
+++ b/plugins/postcss-variable-theming/test/css/3.expect.css
@@ -1,4 +1,4 @@
 
-          html {
-            font-weight: var(--a--b--c-font-weight, var(--a--b--y-font-weight, var(--a--x-font-weight, bold)));
-          }
+      html {
+        font-weight: var(--a--b--c-font-weight, var(--a--b--y-font-weight, var(--a--x-font-weight, bold)));
+      }


### PR DESCRIPTION
* Use `@var` rule name rather than `@theme`
* Support rest parameters as fallback name
* Add an `atRuleName` option
* Allow an empty string for `propDelimiter` and `nestedThemeDelimiter` options
